### PR TITLE
Fix the bug where a navbar was shown in non-daily notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "daily-note-bar",
-	"version": "0.0.1",
+	"name": "daily-note-navbar",
+	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "daily-note-bar",
-			"version": "0.0.1",
+			"name": "daily-note-navbar",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"obsidian-daily-notes-interface": "^0.9.4"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { moment, Plugin, FileView, Notice } from 'obsidian';
+import { moment, Plugin, Notice, MarkdownView } from 'obsidian';
 import { appHasDailyNotesPluginLoaded, createDailyNote, getAllDailyNotes, getDailyNote } from 'obsidian-daily-notes-interface';
 import { createDailyNoteNavbar } from './daily-note-navbar';
 import { DailyNoteNavbarSettings, DEFAULT_SETTINGS, DailyNoteNavbarSettingTab } from './settings';
@@ -28,21 +28,21 @@ export default class DailyNoteNavbarPlugin extends Plugin {
 			return;
 		} 
 
-		// Get markdown workspaces
-		const workspaces = this.app.workspace.getLeavesOfType("markdown");
+		// Get markdown leaves
+		const leaves = this.app.workspace.getLeavesOfType("markdown");
 
-		for (const workspace of workspaces) {
+		for (const leaf of leaves) {
 			// Get view header title container
-			const view = workspace.view;
+			const view = leaf.view as MarkdownView;
+			// Check if view has an active file
+			const activeFile = view.file;
+			if (!activeFile) {
+				continue;
+			}
+
 			const viewHeaderTitleElements = view.containerEl.getElementsByClassName("view-header-title-container");
 
 			for (let i = 0; i < viewHeaderTitleElements.length; i++) {
-				// Check if view has an active file
-				const activeFile = (view as FileView).file;
-				if (!activeFile) {
-					continue;
-				}
-
 				const viewHeaderTitleEl = viewHeaderTitleElements[i] as HTMLElement;
 
 				// Remove old daily note bar

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function getDatesInWeekByDate(date: moment.Moment): moment.Moment[] {
  * @returns {moment.Moment} Returns the date or null if there is no date.
  */
 export function getDateFromFileName(filename: string, dateFormat: string): moment.Moment {
-	return this.currentDate = moment(filename.split(".")[0], dateFormat);
+	return this.currentDate = moment(filename.split(".")[0], dateFormat, true);
 }
 
 /**


### PR DESCRIPTION
Hi, thank you a lot for this wonderful plugin!

I noticed that a navbar can be shown even if the note is not a daily note.
Specifically, it happens when the note title contains a year, e.g. `My note 2024.md`.

This is because `moment` is not passed `true` as its third parameter (strict mode):
- https://momentjs.com/docs/#/parsing/:~:text=You%20can%20use%20strict%20mode%2C%20which%20will%20identify%20the%20parsing%20error%20and%20set%20the%20Moment%20object%20as%20invalid%3A
- https://momentjs.com/guides/#/parsing/strict-mode/

I also fixed a misuse of the term "workspace"; it should be "leaf" instead.
Please see https://docs.obsidian.md/Plugins/User+interface/Workspace for the details.
