### PR TITLE
Add New buttons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Daily Note Navbar",
 	"version": "0.2.1",
 	"minAppVersion": "0.15.0",
-	"description": "Navigate between sequential daily notes with ease.",
+	"description": "Navigate between sequential daily notes and weekly notes with ease.",
 	"author": "Karsten F. Pedersen",
 	"authorUrl": "https://github.com/karstenpedersen",
 	"isDesktopOnly": false

--- a/src/dailyNoteNavbar/dailyNoteNavbar.ts
+++ b/src/dailyNoteNavbar/dailyNoteNavbar.ts
@@ -1,7 +1,7 @@
 import { ButtonComponent, MarkdownView, Notice, Menu, moment, Keymap } from "obsidian";
-import { getAllDailyNotes, getDailyNote } from "obsidian-daily-notes-interface";
-import { getDatesInWeekByDate, getDateFromFileName } from "../utils"; 
-import { FileOpenType } from "../types"; 
+import { getAllDailyNotes, getDailyNote, getAllWeeklyNotes, getWeeklyNote } from "obsidian-daily-notes-interface";
+import { getDatesInWeekByDate, getDateFromFileName, getLastSunday, getNextMonday, getWeeklyNoteFile } from "../utils";
+import { FileOpenType } from "../types";
 import { FILE_OPEN_TYPES_MAPPING, FILE_OPEN_TYPES_TO_PANE_TYPE } from "./consts";
 import { getDailyNoteFile } from "../utils";
 import DailyNoteNavbarPlugin from "../main";
@@ -45,7 +45,51 @@ export default class DailyNoteNavbar {
 		this.containerEl.replaceChildren();
 
 		const currentDate = moment();
-		const dates = getDatesInWeekByDate(this.date.clone().add(this.weekOffset, "week"), this.plugin.settings.firstDayOfWeek);
+		const baseDate = this.date.clone().add(this.weekOffset, "week");
+		const dates = getDatesInWeekByDate(baseDate, this.plugin.settings.firstDayOfWeek);
+
+		// Calculate extra button dates
+		const lastSunday = getLastSunday(baseDate, this.plugin.settings.firstDayOfWeek);
+		const nextMonday = getNextMonday(baseDate, this.plugin.settings.firstDayOfWeek);
+
+		// ========== Weekly note button (if enabled) ==========
+		if (this.plugin.settings.enableWeeklyNoteButton && this.plugin.hasWeeklyNotesDependencies()) {
+			// Calculate week start date for weekly note
+			let weekStart = baseDate.clone().startOf('isoWeek');
+			if (this.plugin.settings.firstDayOfWeek === "Sunday") {
+				if (weekStart.weekday() === 1) {
+					weekStart.subtract(1, "day");
+				}
+			}
+
+			const allWeeklyNotes = getAllWeeklyNotes();
+			const weeklyNote = getWeeklyNote(weekStart, allWeeklyNotes);
+			const weekNumber = weekStart.format(this.plugin.settings.weeklyNoteDisplayFormat);
+
+			const weeklyNoteButton = new ButtonComponent(this.containerEl)
+				.setClass("daily-note-navbar__date")
+				.setClass(weeklyNote ? "daily-note-navbar__default" : "daily-note-navbar__not-exists")
+				.setButtonText(`W${weekNumber}`)
+				.setTooltip(`Open weekly note for week ${weekNumber}`);
+
+			weeklyNoteButton.buttonEl.onClickEvent((event: MouseEvent) => {
+				const paneType = Keymap.isModEvent(event);
+				if (paneType && paneType !== true) {
+					const openType = FILE_OPEN_TYPES_TO_PANE_TYPE[paneType];
+					this.plugin.openWeeklyNote(weekStart, openType);
+				} else if (event.type === "click") {
+					const openType = event.ctrlKey ? "New tab" : this.plugin.settings.weeklyNoteOpenType;
+					this.plugin.openWeeklyNote(weekStart, openType);
+				} else if (event.type === "auxclick") {
+					this.createWeeklyNoteContextMenu(event, weekStart);
+				}
+			});
+		}
+
+		// Last Sunday button (if enabled)
+		if (this.plugin.settings.showExtraButtons) {
+			this.createDateButton(lastSunday, currentDate, true);
+		}
 
 		// Previous week button
 		new ButtonComponent(this.containerEl)
@@ -59,39 +103,7 @@ export default class DailyNoteNavbar {
 
 		// Daily note buttons
 		for (const date of dates) {
-			const dateString = date.format("YYYY-MM-DD");
-			const isActive = this.date.format("YYYY-MM-DD") === dateString;
-			const isCurrent = currentDate.format("YYYY-MM-DD") === dateString;
-			const exists = getDailyNote(date, getAllDailyNotes());
-			const stateClass = isActive ? "daily-note-navbar__active" : exists ? "daily-note-navbar__default" : "daily-note-navbar__not-exists"; 
-
-			const button = new ButtonComponent(this.containerEl)
-				.setClass("daily-note-navbar__date")
-				.setClass(stateClass)
-				.setButtonText(`${date.format(this.plugin.settings.dateFormat)} ${date.date()}`)
-				.setTooltip(`${date.format(this.plugin.settings.tooltipDateFormat)}`);
-			if (isCurrent) {
-				button.setClass("daily-note-navbar__current");
-			}
-
-			// Add context menu
-			button.buttonEl.onClickEvent((event: MouseEvent) => {
-				const paneType = Keymap.isModEvent(event);
-				if (paneType && paneType !== true) {
-					const openType = FILE_OPEN_TYPES_TO_PANE_TYPE[paneType];
-					this.plugin.openDailyNote(date, openType);
-				} else if (event.type === "click") {
-					const openType = event.ctrlKey ? "New tab" : this.plugin.settings.defaultOpenType;
-					// Skip as it is already open
-					const isActive = this.date.format("YYYY-MM-DD") === date.format("YYYY-MM-DD");
-					if (isActive && openType === "Active") {
-						return;
-					}
-					this.plugin.openDailyNote(date, openType);
-				} else if (event.type === "auxclick") {
-					this.createContextMenu(event, date);
-				}
-			});
+			this.createDateButton(date, currentDate);
 		}
 
 		// Next week button
@@ -103,6 +115,11 @@ export default class DailyNoteNavbar {
 				this.weekOffset++;
 				this.rerender();
 			});
+
+		// Next Monday button (if enabled)
+		if (this.plugin.settings.showExtraButtons) {
+			this.createDateButton(nextMonday, currentDate, true);
+		}
 	}
 
 	createContextMenu(event: MouseEvent, date: moment.Moment) {
@@ -133,5 +150,72 @@ export default class DailyNoteNavbar {
 			}));
 
 		menu.showAtMouseEvent(event)
+	}
+
+	createWeeklyNoteContextMenu(event: MouseEvent, weekStart: moment.Moment) {
+		const menu = new Menu();
+
+		for (const [openType, itemValues] of Object.entries(FILE_OPEN_TYPES_MAPPING)) {
+			menu.addItem(item => item
+				.setIcon(itemValues.icon)
+				.setTitle(itemValues.title)
+				.onClick(async () => {
+					this.plugin.openWeeklyNote(weekStart, openType as FileOpenType);
+				}))
+		}
+
+		menu.addSeparator();
+
+		menu.addItem(item => item
+			.setIcon("copy")
+			.setTitle("Copy Obsidian URL")
+			.onClick(async () => {
+				const weeklyNote = await getWeeklyNoteFile(weekStart);
+				const extensionLength = weeklyNote.extension.length > 0 ? weeklyNote.extension.length + 1 : 0;
+				const fileName = encodeURIComponent(weeklyNote.path.slice(0, -extensionLength));
+				const vaultName = this.plugin.app.vault.getName();
+				const url = `obsidian://open?vault=${vaultName}&file=${fileName}`;
+				navigator.clipboard.writeText(url);
+				new Notice("URL copied to your clipboard");
+			}));
+
+		menu.showAtMouseEvent(event);
+	}
+
+	createDateButton(date: moment.Moment, currentDate: moment.Moment, isExtra = false) {
+		const dateString = date.format("YYYY-MM-DD");
+		const isActive = this.date.format("YYYY-MM-DD") === dateString;
+		const isCurrent = currentDate.format("YYYY-MM-DD") === dateString;
+		const exists = getDailyNote(date, getAllDailyNotes());
+		const stateClass = isActive ? "daily-note-navbar__active" : exists ? "daily-note-navbar__default" : "daily-note-navbar__not-exists";
+
+		const button = new ButtonComponent(this.containerEl)
+			.setClass("daily-note-navbar__date")
+			.setClass(stateClass)
+			.setButtonText(`${date.format(this.plugin.settings.dateFormat)} ${date.date()}`)
+			.setTooltip(`${date.format(this.plugin.settings.tooltipDateFormat)}`);
+		if (isCurrent) {
+			button.setClass("daily-note-navbar__current");
+		}
+		if (isExtra) {
+			button.setClass("daily-note-navbar__extra");
+		}
+
+		button.buttonEl.onClickEvent((event: MouseEvent) => {
+			const paneType = Keymap.isModEvent(event);
+			if (paneType && paneType !== true) {
+				const openType = FILE_OPEN_TYPES_TO_PANE_TYPE[paneType];
+				this.plugin.openDailyNote(date, openType);
+			} else if (event.type === "click") {
+				const openType = event.ctrlKey ? "New tab" : this.plugin.settings.defaultOpenType;
+				const isActive = this.date.format("YYYY-MM-DD") === date.format("YYYY-MM-DD");
+				if (isActive && openType === "Active") {
+					return;
+				}
+				this.plugin.openDailyNote(date, openType);
+			} else if (event.type === "auxclick") {
+				this.createContextMenu(event, date);
+			}
+		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Plugin, TFile, Notice, MarkdownView, WorkspaceLeaf } from 'obsidian';
 import { DailyNoteNavbarSettings, DEFAULT_SETTINGS, DailyNoteNavbarSettingTab } from './settings';
 import { FileOpenType } from './types';
-import { getDateFromFileName, getDailyNoteFile, hideChildren, showChildren, selectNavbarFromView } from './utils';
+import { getDateFromFileName, getDailyNoteFile, getWeeklyNoteFile, hideChildren, showChildren, selectNavbarFromView } from './utils';
 import DailyNoteNavbar from './dailyNoteNavbar/dailyNoteNavbar';
 
 /**
@@ -98,6 +98,21 @@ export default class DailyNoteNavbarPlugin extends Plugin {
 		this.openFile(dailyNote, openType);
 	}
 
+	async openWeeklyNote(date: moment.Moment, openType: FileOpenType) {
+		if (!this.hasWeeklyNotesDependencies()) {
+			new Notice("Weekly Notes are not enabled. Please enable them in Periodic Notes.");
+			return;
+		}
+
+		try {
+			const weeklyNote = await getWeeklyNoteFile(date);
+			this.openFile(weeklyNote, openType);
+		} catch (error) {
+			console.error("Failed to open weekly note:", error);
+			new Notice("Failed to open weekly note. Please check your settings.");
+		}
+	}
+
 	async openFile(file: TFile, openType: FileOpenType) {
 		switch (openType) {
 			case "New window":
@@ -147,6 +162,12 @@ export default class DailyNoteNavbarPlugin extends Plugin {
 
 		new Notice("Daily Note Navbar: Enable Periodic Notes or Daily Notes");
 		return false;
+	}
+
+	hasWeeklyNotesDependencies(): boolean {
+		// @ts-ignore
+		const periodicNotes = this.app.plugins.getPlugin("periodic-notes");
+		return periodicNotes?.settings?.weekly?.enabled ?? false;
 	}
 
 	async loadSettings() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,24 +4,44 @@ import { toRecord } from "./utils";
 import DailyNoteBarPlugin from "./main";
 
 export interface DailyNoteNavbarSettings {
+	// Daily Notes settings
 	dateFormat: string;
 	tooltipDateFormat: string;
 	dailyNoteDateFormat: string;
-	firstDayOfWeek: FirstDayOfWeek;
 	defaultOpenType: FileOpenType;
+
+	// Weekly Notes settings
+	enableWeeklyNoteButton: boolean;
+	weeklyNoteDateFormat: string;
+	weeklyNoteDisplayFormat: string;
+	weeklyNoteOpenType: FileOpenType;
+
+	// General settings
+	firstDayOfWeek: FirstDayOfWeek;
 	setActive: boolean;
+	showExtraButtons: boolean;
 }
 
 /**
  * The plugins default settings.
  */
 export const DEFAULT_SETTINGS: DailyNoteNavbarSettings = {
+	// Daily Notes
 	dateFormat: "ddd",
 	tooltipDateFormat: "YYYY-MM-DD",
 	dailyNoteDateFormat: "YYYY-MM-DD",
-	firstDayOfWeek: "Monday",
 	defaultOpenType: "Active",
-	setActive: true
+
+	// Weekly Notes
+	enableWeeklyNoteButton: false,
+	weeklyNoteDateFormat: "gggg-[W]ww",
+	weeklyNoteDisplayFormat: "ww",
+	weeklyNoteOpenType: "Active",
+
+	// General
+	firstDayOfWeek: "Monday",
+	setActive: true,
+	showExtraButtons: false
 }
 
 /**
@@ -39,10 +59,12 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		// Daily note name format
+		// ========== Daily Notes ==========
+		containerEl.createEl('h2', { text: 'Daily Notes' });
+
 		new Setting(containerEl)
-			.setName('Daily note date format')
-			.setDesc('Date format for daily notes.')
+			.setName('Daily note file format')
+			.setDesc('Date format for daily note filenames.')
 			.addText(text => text
 				.setPlaceholder(DEFAULT_SETTINGS.dailyNoteDateFormat)
 				.setValue(this.plugin.settings.dailyNoteDateFormat)
@@ -52,13 +74,12 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 					}
 					this.plugin.settings.dailyNoteDateFormat = value;
 					await this.plugin.saveSettings();
-					this.plugin.addDailyNoteNavbar();
+					this.plugin.rerenderNavbars();
 				}));
 
-		// Date format
 		new Setting(containerEl)
-			.setName('Date format')
-			.setDesc('Date format for the daily note bar.')
+			.setName('Daily note display format')
+			.setDesc('Date format for displaying daily notes in the navbar.')
 			.addText(text => text
 				.setPlaceholder(DEFAULT_SETTINGS.dateFormat)
 				.setValue(this.plugin.settings.dateFormat)
@@ -68,12 +89,11 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 					}
 					this.plugin.settings.dateFormat = value;
 					await this.plugin.saveSettings();
-					this.plugin.addDailyNoteNavbar();
+					this.plugin.rerenderNavbars();
 				}));
 
-		// Tooltip date format
 		new Setting(containerEl)
-			.setName('Tooltip date format')
+			.setName('Daily note tooltip format')
 			.setDesc('Date format for tooltips.')
 			.addText(text => text
 				.setPlaceholder(DEFAULT_SETTINGS.tooltipDateFormat)
@@ -84,10 +104,78 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 					}
 					this.plugin.settings.tooltipDateFormat = value;
 					await this.plugin.saveSettings();
-					this.plugin.addDailyNoteNavbar();
+					this.plugin.rerenderNavbars();
 				}));
 
-		// First day of week
+		new Setting(containerEl)
+			.setName('Open daily notes in')
+			.setDesc('Where to open daily notes.')
+			.addDropdown(dropdown => dropdown
+				.addOptions(toRecord(FILE_OPEN_TYPES.map((item) => item)))
+				.setValue(this.plugin.settings.defaultOpenType)
+				.onChange(async (value: FileOpenType) => {
+					this.plugin.settings.defaultOpenType = value;
+					await this.plugin.saveSettings();
+				}));
+
+		// ========== Weekly Notes ==========
+		containerEl.createEl('h2', { text: 'Weekly Notes' });
+
+		new Setting(containerEl)
+			.setName('Enable weekly note button')
+			.setDesc('Add a button to navigate to the weekly note for the current week.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.enableWeeklyNoteButton)
+				.onChange(async value => {
+					this.plugin.settings.enableWeeklyNoteButton = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerenderNavbars();
+				}));
+
+		new Setting(containerEl)
+			.setName('Weekly note file format')
+			.setDesc('Date format for weekly note filenames (must match your Periodic Notes setting).')
+			.addText(text => text
+				.setPlaceholder(DEFAULT_SETTINGS.weeklyNoteDateFormat)
+				.setValue(this.plugin.settings.weeklyNoteDateFormat)
+				.onChange(async (value) => {
+					if (value.trim() === "") {
+						value = DEFAULT_SETTINGS.weeklyNoteDateFormat;
+					}
+					this.plugin.settings.weeklyNoteDateFormat = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerenderNavbars();
+				}));
+
+		new Setting(containerEl)
+			.setName('Weekly note display format')
+			.setDesc('Format for displaying the week number in the button.')
+			.addText(text => text
+				.setPlaceholder(DEFAULT_SETTINGS.weeklyNoteDisplayFormat)
+				.setValue(this.plugin.settings.weeklyNoteDisplayFormat)
+				.onChange(async (value) => {
+					if (value.trim() === "") {
+						value = DEFAULT_SETTINGS.weeklyNoteDisplayFormat;
+					}
+					this.plugin.settings.weeklyNoteDisplayFormat = value;
+					await this.plugin.saveSettings();
+					this.plugin.rerenderNavbars();
+				}));
+
+		new Setting(containerEl)
+			.setName('Open weekly notes in')
+			.setDesc('Where to open weekly notes.')
+			.addDropdown(dropdown => dropdown
+				.addOptions(toRecord(FILE_OPEN_TYPES.map((item) => item)))
+				.setValue(this.plugin.settings.weeklyNoteOpenType)
+				.onChange(async (value: FileOpenType) => {
+					this.plugin.settings.weeklyNoteOpenType = value;
+					await this.plugin.saveSettings();
+				}));
+
+		// ========== General ==========
+		containerEl.createEl('h2', { text: 'General' });
+
 		new Setting(containerEl)
 			.setName('First day of week')
 			.setDesc('The first day in the daily note bar.')
@@ -97,10 +185,9 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 				.onChange(async (value: FirstDayOfWeek) => {
 					this.plugin.settings.firstDayOfWeek = value;
 					await this.plugin.saveSettings();
-					this.plugin.addDailyNoteNavbar();
+					this.plugin.rerenderNavbars();
 				}));
 
-		// Set active
 		new Setting(containerEl)
 			.setName('Open files as active')
 			.setDesc('Make files active when they are opened.')
@@ -111,17 +198,15 @@ export class DailyNoteNavbarSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				}));
 
-		// File open type
 		new Setting(containerEl)
-			.setName('Open in')
-			.setDesc('Where to open files.')
-			.addDropdown(dropdown => dropdown
-				.addOptions(toRecord(FILE_OPEN_TYPES.map((item) => item)))
-				.setValue(this.plugin.settings.defaultOpenType)
-				.onChange(async (value: FileOpenType) => {
-					this.plugin.settings.defaultOpenType = value;
+			.setName('Show extra buttons')
+			.setDesc('Show buttons for last Sunday and next Monday.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.showExtraButtons)
+				.onChange(async value => {
+					this.plugin.settings.showExtraButtons = value;
 					await this.plugin.saveSettings();
-					this.plugin.addDailyNoteNavbar();
+					this.plugin.rerenderNavbars();
 				}));
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,14 @@
 import { View, moment, TFile } from "obsidian";
 import { FirstDayOfWeek } from "./types";
 import DailyNoteNavbar from "./dailyNoteNavbar/dailyNoteNavbar";
-import { createDailyNote, getAllDailyNotes, getDailyNote } from 'obsidian-daily-notes-interface';
+import {
+	createDailyNote,
+	getAllDailyNotes,
+	getDailyNote,
+	createWeeklyNote,
+	getAllWeeklyNotes,
+	getWeeklyNote
+} from 'obsidian-daily-notes-interface';
 
 /**
  * Gets the dates in the entire week that the date is in.
@@ -94,4 +101,59 @@ export function selectNavbarFromView(view: View): string | null {
 		return navbarEl.getAttribute("daily-note-navbar-id");
 	}
 	return null;
+}
+
+/**
+ * Gets the date of the Sunday before the current week.
+ *
+ * @param {moment.Moment} date - The current date.
+ * @param {FirstDayOfWeek} firstDayOfWeek - The first day of week setting.
+ * @returns {moment.Moment} Returns the Sunday before the current week.
+ */
+export function getLastSunday(date: moment.Moment, firstDayOfWeek: FirstDayOfWeek): moment.Moment {
+	const weekDates = getDatesInWeekByDate(date, firstDayOfWeek);
+	const firstDayOfWeekDate = weekDates[0];
+
+	// If first day of week is Monday, Sunday is one day before
+	// If first day of week is Sunday, we need the previous week's Sunday
+	if (firstDayOfWeek === "Monday") {
+		return firstDayOfWeekDate.clone().subtract(1, "day");
+	} else {
+		// firstDayOfWeek is Sunday
+		// The first element is Sunday of current week, so we want Sunday of previous week
+		return firstDayOfWeekDate.clone().subtract(7, "days");
+	}
+}
+
+/**
+ * Gets the date of the Monday after the current week.
+ *
+ * @param {moment.Moment} date - The current date.
+ * @param {FirstDayOfWeek} firstDayOfWeek - The first day of week setting.
+ * @returns {moment.Moment} Returns the Monday after the current week.
+ */
+export function getNextMonday(date: moment.Moment, firstDayOfWeek: FirstDayOfWeek): moment.Moment {
+	const weekDates = getDatesInWeekByDate(date, firstDayOfWeek);
+	const lastDayOfWeekDate = weekDates[6]; // Last day of the week
+
+	// If first day of week is Monday, the last day is Sunday, so Monday is one day after
+	// If first day of week is Sunday, the last day is Saturday, so Monday is two days after
+	if (firstDayOfWeek === "Monday") {
+		return lastDayOfWeekDate.clone().add(1, "day");
+	} else {
+		// firstDayOfWeek is Sunday, last day is Saturday
+		return lastDayOfWeekDate.clone().add(2, "days");
+	}
+}
+
+/**
+ * Gets the weekly note file for the given date.
+ *
+ * @note This creates the weekly note if it doesn't already exist.
+ * @param {moment.Moment} date - The date to get file for.
+ * @return {Promise<TFile>} Returns the weekly note file.
+ */
+export async function getWeeklyNoteFile(date: moment.Moment): Promise<TFile> {
+	const allWeeklyNotes = getAllWeeklyNotes();
+	return getWeeklyNote(date, allWeeklyNotes) ?? await createWeeklyNote(date);
 }

--- a/styles.css
+++ b/styles.css
@@ -31,11 +31,22 @@
 .daily-note-navbar__current {
 	color: var(--interactive-accent);
 }
+
+/* Extra buttons (last Sunday / next Monday) */
+.daily-note-navbar__extra {
+	opacity: 0.75;
+}
+.daily-note-navbar__extra:hover {
+	opacity: 1;
+}
+
 .daily-note-navbar__not-exists {
 	color: var(--color-base-50) !important;
+	opacity: 0.2;
 }
 .daily-note-navbar__not-exists:hover {
 	color: inherit;
+	opacity: 0.5;
 }
 
 /* Change week buttons */


### PR DESCRIPTION
Solved #24

**Add weekly note button support**

- Add settings for weekly notes (enable button, file format, display format, open type)
- Reorganize settings into Daily Notes, Weekly Notes, and General groups
- Add weekly note button to navbar (displayed at the leftmost position)
- Add hasWeeklyNotesDependencies() method to check Periodic Notes
- Add openWeeklyNote() method to open weekly notes
- Add createWeeklyNoteContextMenu() for right-click menu

---

**Add extra buttons feature for extended date navigation**
- Add 'Show extra buttons' setting (default off)
- Show last Sunday button before Previous Week button
- Show next Monday button after Next Week button
- Extra buttons use same interaction behavior as regular date buttons

